### PR TITLE
Fix loading Desmos with webpack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Attempt to bundle the Desmos API using Webpack
 ## Instructions
 
 1. Install [NodeJS v8.X (LTS)](https://nodejs.org/en/download/)
-2. Copy a version of `calculator.js` into the `src/` folder
-2. At command prompt, run:  
-```cmd
-npm install
-npm run
-```
-3. Browser should open at http://localhost:8085
-4. Check the console for errors
+1. Copy a version of `calculator.js` into the `vendor/` folder
+1. Generate a copy of calculator.js with references to window.Desmos removed
+and place it in the src directory using `sed 's/window.Desmos/Desmos/g' < vendor/calculator.js > src/calculator.js`
+1. At command prompt, run:
+    ```cmd
+    npm install
+    npm run start
+    ```
+1. Browser should open at http://localhost:8085

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,22 +1,17 @@
-import calculator from "./calculator";
+import Desmos from "./calculator";
 
-const script = document.createElement("script");
-script.src = calculator;
-script.onload = () => {
-    const elt = document.getElementById("calculator");
+const elt = document.getElementById("calculator");
 
-    var GRAPHING_CONFIG = {
-        images: false,
-        folders: false,
-        notes: false,
-        qwertyKeyboard: false,
-        restrictedFunctions: true,
-        degreeMode: true,
-        branding: false,
-        border: false,
-        plotSingleVariableImplicitEquations: false
-      };
-      
-    Desmos.GraphingCalculator(elt, GRAPHING_CONFIG);
-};
-document.body.append(script);
+var GRAPHING_CONFIG = {
+    images: false,
+    folders: false,
+    notes: false,
+    qwertyKeyboard: false,
+    restrictedFunctions: true,
+    degreeMode: true,
+    branding: false,
+    border: false,
+    plotSingleVariableImplicitEquations: false
+    };
+
+Desmos.GraphingCalculator(elt, GRAPHING_CONFIG);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const webpack = require('webpack');
 
 module.exports = {
     mode: "development",
@@ -11,12 +12,11 @@ module.exports = {
                 test: path.resolve(__dirname, "src/calculator.js"),
                 use: [
                     // Export the Desmos global var
-                    "exports-loader?window.Desmos",
-                    // Set module.exports=undefined to work around Webpack chomping 'define'
-                    // https://github.com/webpack/webpack/issues/386
-                    // Set this=>window to fake closure context as window
-                    // Make jQuery available "globally" for both Desmos & MathQuill
-                    "imports-loader?undefined=>module.exports=undefined,this=>window,jQuery=jquery,window.jQuery=jquery"
+                    "exports-loader?Desmos",
+                    // Set module.exports=undefined and exports=undefined because Desmos has
+                    // dependencies that use UMD preludes that get confused when they are present.
+                    // Set the Desmos variable to an empty object, which will be used as the module export
+                    "imports-loader?undefined=>module.exports=undefined,exports=>undefined,Desmos=>{}"
                 ]
             }
         ]


### PR DESCRIPTION
Note: this currently involves running a text transformation on the
calculator source. I will work on removing the needs for this and supply
an updated build of the API.